### PR TITLE
Add setup docs and init script

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,31 @@ This project uses Maven. To build a shaded JAR:
 mvn package
 ```
 
+## Environment Setup
+
+Create the required Pub/Sub topic, Cloud Storage bucket and BigQuery table before launching the pipeline. The commands below assume you have the `gcloud`, `gsutil` and `bq` CLIs installed and authenticated.
+
+```bash
+# configure your project
+gcloud config set project <gcp-project>
+
+# create the Pub/Sub topic that will contain station IDs
+gcloud pubsub topics create weather_stn_id
+
+# create a bucket for Dataflow output
+gsutil mb -l <region> gs://<bucket>
+
+# create a BigQuery dataset and table for raw JSON
+bq --location=<region> mk <dataset>
+bq mk --table <dataset>.weather_raw raw_json:STRING
+```
+
+All of the above steps can be executed automatically using the `init.sh` script provided in this repository:
+
+```bash
+./init.sh <gcp-project> <region> <bucket> <dataset>
+```
+
 ## Running on Dataflow
 
 Use Maven's `exec:java` goal to launch the pipeline:

--- a/init.sh
+++ b/init.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [ "$#" -ne 4 ]; then
+  echo "Usage: $0 <project-id> <region> <bucket> <dataset>" >&2
+  exit 1
+fi
+
+PROJECT_ID=$1
+REGION=$2
+BUCKET=$3
+DATASET=$4
+
+echo "Configuring project $PROJECT_ID"
+gcloud config set project "$PROJECT_ID" >&2
+
+# Create Pub/Sub topic
+if ! gcloud pubsub topics describe weather_stn_id >/dev/null 2>&1; then
+  gcloud pubsub topics create weather_stn_id
+else
+  echo "Pub/Sub topic weather_stn_id already exists" >&2
+fi
+
+# Create GCS bucket
+if ! gsutil ls -b "gs://$BUCKET" >/dev/null 2>&1; then
+  gsutil mb -p "$PROJECT_ID" -l "$REGION" "gs://$BUCKET"
+else
+  echo "Bucket gs://$BUCKET already exists" >&2
+fi
+
+# Create BigQuery dataset
+if ! bq show "$DATASET" >/dev/null 2>&1; then
+  bq --location="$REGION" mk -d "$DATASET"
+else
+  echo "Dataset $DATASET already exists" >&2
+fi
+
+# Create BigQuery table
+if ! bq show "$DATASET.weather_raw" >/dev/null 2>&1; then
+  bq mk --table "$DATASET.weather_raw" "raw_json:STRING"
+else
+  echo "Table $DATASET.weather_raw already exists" >&2
+fi
+
+echo "Initialization complete."
+


### PR DESCRIPTION
## Summary
- document creating GCP resources required by the pipeline
- provide `init.sh` to automate Pub/Sub, GCS and BigQuery setup

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b43571e20832d9b742d050abd5180