### PR TITLE
Add Dataflow helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,5 +53,11 @@ mvn compile exec:java \
     --apiToken=<api-token>"
 ```
 
+Alternatively, you can use the included helper script:
+
+```bash
+./run.sh <gcp-project> <region> <bucket> <dataset> <api-token>
+```
+
 The pipeline expects the Pub/Sub topic `weather_stn_id` to contain
 station IDs as plain strings.

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ "$#" -ne 5 ]; then
+  echo "Usage: $0 <project-id> <region> <bucket> <dataset> <api-token>" >&2
+  exit 1
+fi
+
+if ! command -v mvn >/dev/null 2>&1; then
+  echo "mvn command not found. Please install Maven." >&2
+  exit 1
+fi
+
+PROJECT_ID=$1
+REGION=$2
+BUCKET=$3
+DATASET=$4
+API_TOKEN=$5
+
+mvn compile exec:java \
+  -Dexec.mainClass=com.example.WeatherPipeline \
+  -Dexec.args="--runner=DataflowRunner \
+    --project=${PROJECT_ID} \
+    --region=${REGION} \
+    --inputTopic=projects/${PROJECT_ID}/topics/weather_stn_id \
+    --outputPath=gs://${BUCKET}/weather/output \
+    --bigQueryTable=${PROJECT_ID}:${DATASET}.weather_raw \
+    --apiToken=${API_TOKEN}"
+


### PR DESCRIPTION
## Summary
- add `run.sh` to wrap the `mvn` command
- document the helper script in `README.md`

## Testing
- `mvn -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b4cc98934832d9f996df400eeff85