### PR TITLE
Add trust store parameters to run script

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,11 @@ mvn compile exec:java \
 Alternatively, you can use the included helper script:
 
 ```bash
-./run.sh <gcp-project> <region> <bucket> <dataset> <api-token>
+./run.sh <gcp-project> <region> <bucket> <dataset> <api-token> [trust-store-secret-id] [trust-store-secret-version]
 ```
+
+If the optional trust store arguments are omitted, the script defaults to `cwa-trust-pem` for the secret ID
+and `latest` for the secret version.
 
 The pipeline expects the Pub/Sub topic `weather_stn_id` to contain
 station IDs as plain strings.

--- a/run.sh
+++ b/run.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
 set -euo pipefail
 
-if [ "$#" -ne 5 ]; then
-  echo "Usage: $0 <project-id> <region> <bucket> <dataset> <api-token>" >&2
+usage() {
+  echo "Usage: $0 <project-id> <region> <bucket> <dataset> <api-token> [trust-store-secret-id] [trust-store-secret-version]" >&2
   exit 1
+}
+
+if [ "$#" -ne 5 ] && [ "$#" -ne 7 ]; then
+  usage
 fi
 
 if ! command -v mvn >/dev/null 2>&1; then
@@ -16,6 +20,13 @@ REGION=$2
 BUCKET=$3
 DATASET=$4
 API_TOKEN=$5
+if [ "$#" -eq 7 ]; then
+  TRUST_STORE_SECRET_ID=$6
+  TRUST_STORE_SECRET_VERSION=$7
+else
+  TRUST_STORE_SECRET_ID="cwa-trust-pem"
+  TRUST_STORE_SECRET_VERSION="latest"
+fi
 
 mvn compile exec:java \
   -Dexec.mainClass=com.example.WeatherPipeline \
@@ -25,5 +36,7 @@ mvn compile exec:java \
     --inputTopic=projects/${PROJECT_ID}/topics/weather_stn_id \
     --outputPath=gs://${BUCKET}/weather/output \
     --bigQueryTable=${PROJECT_ID}:${DATASET}.weather_raw \
-    --apiToken=${API_TOKEN}"
+    --apiToken=${API_TOKEN} \
+    --trustStoreSecretId=${TRUST_STORE_SECRET_ID} \
+    --trustStoreSecretVersion=${TRUST_STORE_SECRET_VERSION}"
 

--- a/src/main/java/com/example/WeatherPipeline.java
+++ b/src/main/java/com/example/WeatherPipeline.java
@@ -80,7 +80,7 @@ public class WeatherPipeline {
     FetchWeatherDoFn(String apiToken, String projectId, String secretId, String secretVersion) {
       this.apiToken = apiToken;
       this.projectId = projectId;
-      this.secretId = (secretId == null || secretId.isEmpty()) ? "cwa-truststore-pem" : secretId;
+      this.secretId = (secretId == null || secretId.isEmpty()) ? "cwa-trust-pem" : secretId;
       this.secretVersion = (secretVersion == null || secretVersion.isEmpty()) ? "latest" : secretVersion;
     }
 


### PR DESCRIPTION
## Summary
- allow optional trust store ID and version arguments in `run.sh`
- document the optional trust store parameters in README
- change default trust store secret to `cwa-trust-pem`

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*
- `apt-get update` *(fails: internet is disabled)*

------
https://chatgpt.com/codex/tasks/task_e_687b9e801778832d9ce2db14e199376e