### PR TITLE
Add teardown script

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,15 @@ and `latest` for the secret version.
 
 The pipeline expects the Pub/Sub topic `weather_stn_id` to contain
 station IDs as plain strings.
+
+## Cleanup
+
+When you are finished you can remove the created resources with the
+`tear_down.sh` script. It deletes the Pub/Sub topic, Cloud Storage bucket
+and BigQuery dataset by default. Individual resources can be skipped
+using the flags shown below. The topic name can also be overridden.
+
+```bash
+./tear_down.sh <gcp-project> <bucket> <dataset> [--topic weather_stn_id] \
+  [--no-topic] [--no-bucket] [--no-dataset]
+```

--- a/tear_down.sh
+++ b/tear_down.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 <project-id> <bucket> <dataset> [--topic name] [--no-topic] [--no-bucket] [--no-dataset]" >&2
+  exit 1
+}
+
+if [ $# -lt 3 ]; then
+  usage
+fi
+
+PROJECT_ID=$1
+BUCKET=$2
+DATASET=$3
+shift 3
+
+TOPIC="weather_stn_id"
+DELETE_TOPIC=true
+DELETE_BUCKET=true
+DELETE_DATASET=true
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --topic)
+      TOPIC="$2"
+      shift 2
+      ;;
+    --no-topic)
+      DELETE_TOPIC=false
+      shift
+      ;;
+    --no-bucket)
+      DELETE_BUCKET=false
+      shift
+      ;;
+    --no-dataset)
+      DELETE_DATASET=false
+      shift
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage
+      ;;
+  esac
+done
+
+echo "Configuring project $PROJECT_ID"
+gcloud config set project "$PROJECT_ID" >&2
+
+if $DELETE_TOPIC; then
+  if gcloud pubsub topics describe "$TOPIC" >/dev/null 2>&1; then
+    gcloud pubsub topics delete "$TOPIC"
+  else
+    echo "Pub/Sub topic $TOPIC does not exist" >&2
+  fi
+fi
+
+if $DELETE_BUCKET; then
+  if gsutil ls -b "gs://$BUCKET" >/dev/null 2>&1; then
+    gsutil -m rm -r "gs://$BUCKET"
+  else
+    echo "Bucket gs://$BUCKET does not exist" >&2
+  fi
+fi
+
+if $DELETE_DATASET; then
+  if bq show "$DATASET.weather_raw" >/dev/null 2>&1; then
+    bq rm -f -t "$DATASET.weather_raw"
+  fi
+  if bq show "$DATASET" >/dev/null 2>&1; then
+    bq rm -f -d "$DATASET"
+  else
+    echo "Dataset $DATASET does not exist" >&2
+  fi
+fi
+
+echo "Teardown complete."


### PR DESCRIPTION
## Summary
- add `tear_down.sh` with options to selectively remove resources
- document cleanup script usage in README

## Testing
- `bash -n tear_down.sh`

------
https://chatgpt.com/codex/tasks/task_e_687c502eba5c832dbbfdd80a6d9f4a86