### PR TITLE
Add configurable job name and topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,24 @@ mvn compile exec:java \
     --outputPath=gs://<bucket>/weather/output \
     --bigQueryTable=<project>:<dataset>.weather_raw \
     --apiToken=<api-token> \
+  --retryAttempts=<retries>"
+```
+
+To reuse the same JAR for a retry workflow, simply provide a different
+`--inputTopic` and set a unique `--jobName` when launching the pipeline. For
+example:
+
+```bash
+mvn compile exec:java \
+  -Dexec.mainClass=com.example.WeatherPipeline \
+  -Dexec.args="--runner=DataflowRunner \
+    --project=<gcp-project> \
+    --region=<region> \
+    --inputTopic=projects/<project>/topics/weather_retry \
+    --jobName=weather-pipeline-retry \
+    --outputPath=gs://<bucket>/weather/output \
+    --bigQueryTable=<project>:<dataset>.weather_raw \
+    --apiToken=<api-token> \
     --retryAttempts=<retries>"
 ```
 
@@ -65,7 +83,7 @@ Alternatively, you can use the included helper script:
 ./run.sh <gcp-project> <region> <bucket> <dataset> <api-token> <retries> [trust-store-secret-id] [trust-store-secret-version]
 ```
 
-Additional API request settings can be provided via environment variables before
+Additional settings can be provided via environment variables before
 running the script:
 
 - `API_BASE_URL` - override the CWA API endpoint
@@ -73,6 +91,8 @@ running the script:
 - `API_HEADERS` - extra HTTP headers as `Header:Value` pairs separated by commas
 - `TOKEN_IN_HEADER` - set to `true` to send the API token in a header
 - `TOKEN_HEADER_NAME` - header name used when `TOKEN_IN_HEADER` is `true`
+- `INPUT_TOPIC` - Pub/Sub topic to read station IDs from
+- `JOB_NAME` - name for the Dataflow job
 
 If the optional trust store arguments are omitted, the script defaults to `cwa-trust-pem` for the secret ID
 and `latest` for the secret version.

--- a/run.sh
+++ b/run.sh
@@ -9,6 +9,8 @@ usage() {
   echo "  API_HEADERS - additional HTTP headers" >&2
   echo "  TOKEN_IN_HEADER - set to true to send token in header" >&2
   echo "  TOKEN_HEADER_NAME - header name when TOKEN_IN_HEADER=true" >&2
+  echo "  INPUT_TOPIC - Pub/Sub topic to read station IDs from" >&2
+  echo "  JOB_NAME - Dataflow job name" >&2
   exit 1
 }
 
@@ -41,11 +43,13 @@ API_DEFAULT_PARAM="${API_DEFAULT_PARAM:-}"
 API_HEADERS="${API_HEADERS:-}"
 TOKEN_IN_HEADER="${TOKEN_IN_HEADER:-false}"
 TOKEN_HEADER_NAME="${TOKEN_HEADER_NAME:-Authorization}"
+INPUT_TOPIC="${INPUT_TOPIC:-projects/${PROJECT_ID}/topics/weather_stn_id}"
+JOB_NAME="${JOB_NAME:-}"
 
 ARGS="--runner=DataflowRunner \
   --project=${PROJECT_ID} \
   --region=${REGION} \
-  --inputTopic=projects/${PROJECT_ID}/topics/weather_stn_id \
+  --inputTopic=${INPUT_TOPIC} \
   --outputPath=gs://${BUCKET}/weather/output \
   --bigQueryTable=${PROJECT_ID}:${DATASET}.weather_raw \
   --apiToken=${API_TOKEN} \
@@ -59,6 +63,9 @@ if [ -n "$API_DEFAULT_PARAM" ]; then
 fi
 if [ -n "$API_HEADERS" ]; then
   ARGS+=" --apiHeaders=${API_HEADERS}"
+fi
+if [ -n "$JOB_NAME" ]; then
+  ARGS+=" --jobName=${JOB_NAME}"
 fi
 ARGS+=" --tokenInHeader=${TOKEN_IN_HEADER}"
 ARGS+=" --tokenHeaderName=${TOKEN_HEADER_NAME}"


### PR DESCRIPTION
## Summary
- document how to use a different `--inputTopic` and `--jobName` for retry runs
- allow configuring `INPUT_TOPIC` and `JOB_NAME` in `run.sh`

## Testing
- `mvn -q -DskipTests package` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_6883a3eacf48832d8d8af793e64cd0a9